### PR TITLE
Update Springdoc 2 so Swagger can work with Springboot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,10 +106,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.6.14</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
https://springdoc.org/#what-is-the-compatibility-matrix-of-springdoc-openapi-with-spring-boot

official docs say only springdoc 2 supports springboot 3