### PR TITLE
Update the ALL endpoint controller

### DIFF
--- a/src/main/java/au/org/aodn/esindexer/controller/IndexerController.java
+++ b/src/main/java/au/org/aodn/esindexer/controller/IndexerController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.io.IOException;
+import java.util.Map;
 
 @RestController
 @RequestMapping(value = "/api/v1/indexer/index")
@@ -56,7 +57,8 @@ public class IndexerController {
 
     @PostMapping(path="/all", consumes = "application/json", produces = "application/json")
     @Operation(security = { @SecurityRequirement(name = "X-API-Key") }, description = "Index all metadata records from GeoNetwork")
-    public ResponseEntity<String> indexAllMetadataRecords(@RequestParam(value = "confirm", defaultValue = "false") Boolean confirm) throws IOException {
+    public ResponseEntity<String> indexAllMetadataRecords(@RequestBody Map<String, Boolean> requestBody) throws IOException {
+        Boolean confirm = requestBody.getOrDefault("confirm", false);
         return indexerService.indexAllMetadataRecordsFromGeoNetwork(confirm);
     }
 


### PR DESCRIPTION
reason of this PR:

previously, for the `all` endpoint, had to to provide required parameter `confirm` twice in both the URL param and in the body payload. E.g

http://localhost:8081/api/v1/indexer/index/all?confirm=true

AND 

```json
{
    "confirm": true
}
```

this PR will remove the need to declare `confirm` in the URL param, so no more `?confirm=true`