### PR TITLE
Smart suggestions

### DIFF
--- a/indexer/src/main/java/au/org/aodn/esindexer/service/AodnDiscoveryParameterVocabService.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/AodnDiscoveryParameterVocabService.java
@@ -6,7 +6,6 @@ import au.org.aodn.stac.model.ThemesModel;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/AodnDiscoveryParameterVocabService.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/AodnDiscoveryParameterVocabService.java
@@ -1,10 +1,12 @@
 package au.org.aodn.esindexer.service;
 
-import au.org.aodn.esindexer.utils.CacheArdcVocabsUtils;
+import au.org.aodn.esindexer.utils.VocabsUtils;
 import au.org.aodn.stac.model.ConceptModel;
 import au.org.aodn.stac.model.ThemesModel;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -15,7 +17,13 @@ import java.util.List;
 @Service
 public class AodnDiscoveryParameterVocabService {
     @Autowired
-    CacheArdcVocabsUtils cacheArdcVocabsUtils;
+    VocabsUtils cacheArdcVocabsUtils;
+
+    @Value("${elasticsearch.index.categories.name}")
+    String categoriesIndexName;
+
+    @Autowired
+    ElasticsearchClient portalElasticsearchClient;
 
     protected boolean themesMatchConcept(List<ThemesModel> themes, ConceptModel thatConcept) {
         for (ThemesModel theme : themes) {
@@ -44,7 +52,7 @@ public class AodnDiscoveryParameterVocabService {
     public List<String> getAodnDiscoveryCategories(List<ThemesModel> themes) throws IOException {
         List<String> results = new ArrayList<>();
         // Iterate over the top-level vocabularies
-        for (JsonNode topLevelVocab : cacheArdcVocabsUtils.getDiscoveryCategories()) {
+        for (JsonNode topLevelVocab : cacheArdcVocabsUtils.getDiscoveryCategories(categoriesIndexName)) {
             if (topLevelVocab.has("narrower") && !topLevelVocab.get("narrower").isEmpty()) {
                 for (JsonNode secondLevelVocab : topLevelVocab.get("narrower")) {
                     String secondLevelVocabLabel = secondLevelVocab.get("label").asText();

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/AodnDiscoveryParameterVocabService.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/AodnDiscoveryParameterVocabService.java
@@ -19,9 +19,6 @@ public class AodnDiscoveryParameterVocabService {
     @Autowired
     VocabsUtils cacheArdcVocabsUtils;
 
-    @Value("${elasticsearch.index.categories.name}")
-    String categoriesIndexName;
-
     @Autowired
     ElasticsearchClient portalElasticsearchClient;
 
@@ -52,7 +49,7 @@ public class AodnDiscoveryParameterVocabService {
     public List<String> getAodnDiscoveryCategories(List<ThemesModel> themes) throws IOException {
         List<String> results = new ArrayList<>();
         // Iterate over the top-level vocabularies
-        for (JsonNode topLevelVocab : cacheArdcVocabsUtils.getDiscoveryCategories(categoriesIndexName)) {
+        for (JsonNode topLevelVocab : cacheArdcVocabsUtils.getDiscoveryCategories()) {
             if (topLevelVocab.has("narrower") && !topLevelVocab.get("narrower").isEmpty()) {
                 for (JsonNode secondLevelVocab : topLevelVocab.get("narrower")) {
                     String secondLevelVocabLabel = secondLevelVocab.get("label").asText();

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/IndexerServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/IndexerServiceImpl.java
@@ -5,6 +5,7 @@ import au.org.aodn.esindexer.configuration.AppConstants;
 import au.org.aodn.esindexer.exception.*;
 import au.org.aodn.esindexer.utils.JaxbUtils;
 import au.org.aodn.metadata.iso19115_3_2018.*;
+import au.org.aodn.stac.model.RecordSuggest;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.core.*;
@@ -127,13 +128,20 @@ public class IndexerServiceImpl implements IndexerService {
 
         stacCollectionModel.getSummaries().setScore(score);
 
-        // TODO: in future, blah blah here
-        stacCollectionModel.setTitleSuggest(stacCollectionModel.getTitle());
-
         List<String> aodnDiscoveryCategories = aodnDiscoveryParameterVocabService.getAodnDiscoveryCategories(stacCollectionModel.getThemes());
         if (!aodnDiscoveryCategories.isEmpty()) {
             stacCollectionModel.getSummaries().setDiscoveryCategories(aodnDiscoveryCategories);
         }
+
+
+        // categories suggest using a different index
+
+        // extendable for other aspects of the records data. eg. title, description, etc. something that are unique to the record and currently using "text" type
+        RecordSuggest recordSuggest = RecordSuggest.builder()
+                .title(stacCollectionModel.getTitle())
+                .description(null) // purely for demonstrating the extendability, manage extra suggest field in RecordSuggest class, and the index JSON schema
+                .build();
+        stacCollectionModel.setRecordSuggest(recordSuggest);
 
         return stacCollectionModel;
     }

--- a/indexer/src/main/java/au/org/aodn/esindexer/utils/VocabsUtils.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/utils/VocabsUtils.java
@@ -32,7 +32,7 @@ import java.util.List;
 @Component
 // create and inject a stub proxy to self due to the circular reference http://bit.ly/4aFvYtt
 @Scope(proxyMode = ScopedProxyMode.TARGET_CLASS)
-public class CacheArdcVocabsUtils {
+public class VocabsUtils {
     @Value(AppConstants.AODN_DISCOVERY_PARAMETER_VOCAB_API)
     protected String vocabApi;
 
@@ -41,7 +41,7 @@ public class CacheArdcVocabsUtils {
 
     // self-injection to avoid self-invocation problems when calling the cachable method within the same bean
     @Autowired
-    CacheArdcVocabsUtils self;
+    VocabsUtils self;
 
     @Autowired
     ElasticSearchIndexService elasticSearchIndexService;
@@ -112,7 +112,7 @@ public class CacheArdcVocabsUtils {
     @Cacheable(AppConstants.AODN_DISCOVERY_CATEGORIES_CACHE)
     // TODO research strategy to avoid multiple refresh runs at the same schedule by multiple indexer instances
     // A way to do it is read the value from Elastic search, if it has updated within say 24 hrs then use it
-    public List<JsonNode> getDiscoveryCategories() throws IOException {
+    public List<JsonNode> getDiscoveryCategories(String categoriesIndexName) throws IOException {
         List<JsonNode> categories = new ArrayList<>();
         log.info("Fetching AODN Discovery Parameter Vocabularies from {}", categoriesIndexName);
         try {
@@ -140,7 +140,7 @@ public class CacheArdcVocabsUtils {
         log.info("Refreshing AODN Discovery Parameter Vocabularies cache");
         clearCache();
         this.refreshDiscoveryCategoriesIndex();
-        self.getDiscoveryCategories();
+        self.getDiscoveryCategories(categoriesIndexName);
     }
 
     @CacheEvict(value = AppConstants.AODN_DISCOVERY_CATEGORIES_CACHE, allEntries = true)

--- a/indexer/src/main/java/au/org/aodn/esindexer/utils/VocabsUtils.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/utils/VocabsUtils.java
@@ -112,7 +112,7 @@ public class VocabsUtils {
     @Cacheable(AppConstants.AODN_DISCOVERY_CATEGORIES_CACHE)
     // TODO research strategy to avoid multiple refresh runs at the same schedule by multiple indexer instances
     // A way to do it is read the value from Elastic search, if it has updated within say 24 hrs then use it
-    public List<JsonNode> getDiscoveryCategories(String categoriesIndexName) throws IOException {
+    public List<JsonNode> getDiscoveryCategories() throws IOException {
         List<JsonNode> categories = new ArrayList<>();
         log.info("Fetching AODN Discovery Parameter Vocabularies from {}", categoriesIndexName);
         try {
@@ -140,7 +140,7 @@ public class VocabsUtils {
         log.info("Refreshing AODN Discovery Parameter Vocabularies cache");
         clearCache();
         this.refreshDiscoveryCategoriesIndex();
-        self.getDiscoveryCategories(categoriesIndexName);
+        self.getDiscoveryCategories();
     }
 
     @CacheEvict(value = AppConstants.AODN_DISCOVERY_CATEGORIES_CACHE, allEntries = true)

--- a/indexer/src/main/resources/config_files/aodn_discovery_parameter_vocabularies_index.json
+++ b/indexer/src/main/resources/config_files/aodn_discovery_parameter_vocabularies_index.json
@@ -1,16 +1,28 @@
 {
+  "settings":{
+    "analysis":{
+      "analyzer":{
+        "custom_analyser":{
+          "type":"custom",
+          "tokenizer":"standard",
+          "filter":[
+            "lowercase",
+            "english_stop"
+          ]
+        }
+      },
+      "filter":{
+        "english_stop":{
+          "type":"stop",
+          "stopwords":"_english_"
+        }
+      }
+    }
+  },
   "mappings": {
     "dynamic": true,
     "properties": {
-      "label": {
-        "type": "text",
-        "fields": {
-          "keyword": {
-            "type": "keyword",
-            "ignore_above": 256
-          }
-        }
-      },
+      "label": { "type":  "search_as_you_type", "analyzer": "custom_analyser" },
       "definition": {
         "type": "text"
       },
@@ -20,15 +32,7 @@
       "broader": {
         "type": "nested",
         "properties": {
-          "label": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
+          "label": { "type":  "text" },
           "about": {
             "type": "keyword"
           }
@@ -37,30 +41,14 @@
       "narrower": {
         "type": "nested",
         "properties": {
-          "label": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
+          "label": { "type": "text" },
           "about": {
             "type": "keyword"
           },
           "narrower": {
             "type": "nested",
             "properties": {
-              "label": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
+              "label": { "type":  "text" },
               "about": {
                 "type": "keyword"
               }

--- a/indexer/src/main/resources/config_files/portal_records_index_schema.json
+++ b/indexer/src/main/resources/config_files/portal_records_index_schema.json
@@ -29,9 +29,12 @@
       "stac_version": { "type": "text" },
       "type": { "type": "text" },
       "title": { "type": "text" },
-      "title_suggest": {
-        "type": "search_as_you_type",
-        "analyzer": "custom_analyser"
+      "record_suggest": {
+        "type": "nested",
+        "properties": {
+          "title": { "type": "search_as_you_type", "analyzer": "custom_analyser" },
+          "description": { "type": "search_as_you_type", "analyzer": "custom_analyser" }
+        }
       },
       "discovery_categories" : { "type":  "keyword" },
       "keywords": {

--- a/indexer/src/test/java/au/org/aodn/esindexer/utils/VocabUtilsTest.java
+++ b/indexer/src/test/java/au/org/aodn/esindexer/utils/VocabUtilsTest.java
@@ -1,13 +1,10 @@
 package au.org.aodn.esindexer.utils;
 
-import au.org.aodn.ardcvocabs.configuration.ArdcAutoConfiguration;
 import au.org.aodn.esindexer.service.AodnDiscoveryParameterVocabService;
 import au.org.aodn.stac.model.ConceptModel;
 import au.org.aodn.stac.model.ThemesModel;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -23,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles("test")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class AodnDiscoveryParameterVocabUtilsTest {
+public class VocabUtilsTest {
     @Autowired
     AodnDiscoveryParameterVocabService aodnDiscoveryParameterVocabService;
 

--- a/indexer/src/test/resources/canned/sample4_stac.json
+++ b/indexer/src/test/resources/canned/sample4_stac.json
@@ -246,7 +246,9 @@
     "title" : "AODN Discovery Parameter Vocabulary"
   } ],
   "id" : "7709f541-fc0c-4318-b5b9-9053aa474e0e",
-  "title_suggest" : "Ocean acidification historical reconstruction",
+  "record_suggest" : {
+    "title" : "Ocean acidification historical reconstruction"
+  },
   "type" : "Collection",
   "stac_version" : "1.0.0",
   "stac_extensions" : [ "https://stac-extensions.github.io/scientific/v1.0.0/schema.json", "https://stac-extensions.github.io/contacts/v0.1.1/schema.json", "https://stac-extensions.github.io/projection/v1.1.0/schema.json", "https://stac-extensions.github.io/language/v1.0.0/schema.json", "https://stac-extensions.github.io/themes/v1.0.0/schema.json" ]

--- a/stacmodel/src/main/java/au/org/aodn/stac/model/RecordSuggest.java
+++ b/stacmodel/src/main/java/au/org/aodn/stac/model/RecordSuggest.java
@@ -1,0 +1,11 @@
+package au.org.aodn.stac.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RecordSuggest {
+    private String title;
+    private String description;
+}

--- a/stacmodel/src/main/java/au/org/aodn/stac/model/StacCollectionModel.java
+++ b/stacmodel/src/main/java/au/org/aodn/stac/model/StacCollectionModel.java
@@ -14,8 +14,8 @@ public class StacCollectionModel {
     @JsonProperty("id")
     protected String uuid;
     protected String title;
-    @JsonProperty("title_suggest")
-    protected String titleSuggest;
+    @JsonProperty("record_suggest")
+    protected RecordSuggest recordSuggest;
     protected String description;
     protected ExtentModel extent;
     protected SummariesModel summaries;


### PR DESCRIPTION
I've tried to define the categories schema for second-level vocabs to be suggested with `completion suggester`, works great BUT it may not be too ideal for cases that the input from the users isn't at the front of the matching results.

for example:

`completion suggester` querying for `air`

```json
POST discovery_category/_search?pretty
{
    "_source": ["narrower.label"],
  "suggest": {
    "categories-suggest": {
      "prefix": "air",
      "completion": {
        "field": "narrower.label",
        "skip_duplicates": true
      }
    }
  }
}
```

we will get `air pressure` category suggested

```json
{
  "took": 1,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 0,
      "relation": "eq"
    },
    "max_score": null,
    "hits": []
  },
  "suggest": {
    "categories-suggest": [
      {
        "text": "air",
        "offset": 0,
        "length": 3,
        "options": [
          {
            "text": "Air pressure",
            "_index": "discovery_category",
            "_id": "G4zzCY8BSmZODJMJkjb9",
            "_nested": {
              "field": "narrower",
              "offset": 0
            },
            "_score": 1,
            "_source": {
              "label": "Air pressure"
            }
          },
          {
            "text": "Air-Sea Fluxes",
            "_index": "discovery_category",
            "_id": "G4zzCY8BSmZODJMJkjb9",
            "_nested": {
              "field": "narrower",
              "offset": 2
            },
            "_score": 1,
            "_source": {
              "label": "Air-Sea Fluxes"
            }
          }
        ]
      }
    ]
  }
}
```

🆘  if I query for `pressure`, my expectation also be `sea pressure`; but in fact, I won't be suggested `sea pressure`, because `pressure` is at the back of `sea pressure`.

The `completion suggester` is optimised for speed, the ability to fine tune it is very limited comparing to `search_as_you_type`. ElasticSearch says it is not meant for `phrase` or `term` queries btw: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#completion-suggester

> It is not meant for spell correction or did-you-mean functionality like the term or phrase suggesters.

So I will use `search_as_you_type` for suggesting categories.

it works great

querying
```json
POST /discovery_category/_search?typed_keys=true
{
  "_source": {
    "includes": [
      "label"
    ]
  },
  "query": {
    "bool": {
      "filter": [
        {
          "bool": {
            "must": [
              {
                "nested": {
                  "path": "broader",
                  "query": {
                    "exists": {
                      "field": "broader"
                    }
                  }
                }
              }
            ]
          }
        }
      ],
      "must": [
        {
          "multi_match": {
            "fields": [
              "label",
              "label._2gram",
              "label._3gram"
            ],
            "fuzziness": "AUTO",
            "query": "pres",
            "type": "bool_prefix"
          }
        }
      ]
    }
  }
}
```

results:

```json
{
  "took": 1,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 2,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "discovery_category",
        "_id": "moyxCo8BSmZODJMJ5z2q",
        "_score": 1,
        "_source": {
          "label": "Air pressure"
        }
      },
      {
        "_index": "discovery_category",
        "_id": "oIyxCo8BSmZODJMJ5z2q",
        "_score": 1,
        "_source": {
          "label": "Water pressure"
        }
      }
    ]
  }
}
```