### PR TITLE
Add overall count to score based on comment in ticket

### DIFF
--- a/indexer/src/main/java/au/org/aodn/esindexer/service/RankingServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/RankingServiceImpl.java
@@ -42,7 +42,7 @@ public class RankingServiceImpl implements RankingService {
 
     public Integer evaluateCompleteness(StacCollectionModel stacCollectionModel) {
         int total = 0;
-
+        int count = 0;
        /*
         * The implementation of this method can be adjusted
         * https://github.com/aodn/backlog/issues/5233
@@ -71,27 +71,32 @@ public class RankingServiceImpl implements RankingService {
             } else {
                 total += themeMaxWeigth;
             }
+            count++;
         }
         // Lineage
         if (stacCollectionModel.getSummaries() != null && stacCollectionModel.getSummaries().getStatement() != null) {
             log.debug("Lineage found");
             total += lineageWeigth;
+            count++;
         }
         // License
         if (stacCollectionModel.getLicense() != null) {
             log.debug("License found");
             total += licenseWeigth;
+            count++;
         }
         // Constraint (citation)
         if (stacCollectionModel.getCitation() != null) {
             log.debug("Citation found");
             total += citationWeigth;
+            count++;
         }
         // Abstract
         if (stacCollectionModel.getDescription() != null && !stacCollectionModel.getDescription().isBlank()) {
             log.debug("Description found");
             int w = (int) (stacCollectionModel.getDescription().length() * descriptionWeigth);
             total += Math.min(w, 25);
+            count++;
         }
         // Links
         if (stacCollectionModel.getLinks() != null && !stacCollectionModel.getLinks().isEmpty()) {
@@ -105,8 +110,9 @@ public class RankingServiceImpl implements RankingService {
             else {
                 total += linkMaxWeigth;
             }
+            count++;
         }
-
-        return total;
+        // The more field exist, the higher the mark
+        return total + count;
     }
 }

--- a/indexer/src/test/java/au/org/aodn/esindexer/service/RankingServiceTests.java
+++ b/indexer/src/test/java/au/org/aodn/esindexer/service/RankingServiceTests.java
@@ -61,7 +61,7 @@ class RankingServiceTests extends BaseTestClass {
         // arrange
         stacCollectionModel.setDescription("The Cape Grim Baseline Air Pollution Station facility, located at the North/West tip of Tasmania (40� 41'S, 144� 41'E), is funded and managed by the Australian Bureau of Meteorology, with the scientific program being jointly supervised with CSIRO Marine and Atmospheric Research. This archive contains 1000 litre air samples contained in stainless steel flasks collected at approximately 3 monthly intervals since 1978. The archive is housed at the Aspendale laboratory of CSIRO Marine and Atmospheric Research. The Cape Grim air archive is invaluable in determining the past atmospheric composition of a wide range of gases. For some of these gases, accurate and precise analytical methods have only recently evolved (for example HFCs and PFCs). The measurements are state-of-the-art in precision and accuracy. They are used to identify trace gas trends in the Southern Hemisphere, which in turn can be used to drive climate change models and identify processes that influence changes to the atmosphere.");
         // assert
-        assertEquals(10, mockRankingService.evaluateCompleteness(stacCollectionModel));
+        assertEquals(11, mockRankingService.evaluateCompleteness(stacCollectionModel));
         verify(mockRankingService, times(1)).evaluateCompleteness(stacCollectionModel);
     }
 
@@ -86,8 +86,7 @@ class RankingServiceTests extends BaseTestClass {
 
         stacCollectionModel.setLinks(links);
 
-        // assert
-        assertEquals(15, mockRankingService.evaluateCompleteness(stacCollectionModel));
+        assertEquals(16, mockRankingService.evaluateCompleteness(stacCollectionModel));
         verify(mockRankingService, times(1)).evaluateCompleteness(stacCollectionModel);
     }
 
@@ -106,8 +105,8 @@ class RankingServiceTests extends BaseTestClass {
 
         stacCollectionModel.setThemes(themes);
 
-        // assert
-        assertEquals(mockRankingService.linkMinWeigth, mockRankingService.evaluateCompleteness(stacCollectionModel));
+        // assert, because only 1 field found, so we add 1 to the weight
+        assertEquals(mockRankingService.linkMinWeigth + 1, mockRankingService.evaluateCompleteness(stacCollectionModel));
         verify(mockRankingService, times(1)).evaluateCompleteness(stacCollectionModel);
     }
 
@@ -121,8 +120,8 @@ class RankingServiceTests extends BaseTestClass {
                 .build()
         );
 
-        // assert
-        assertEquals(mockRankingService.lineageWeigth, mockRankingService.evaluateCompleteness(stacCollectionModel));
+        // assert, because only 1 field found, so we add 1 to the weight
+        assertEquals(mockRankingService.lineageWeigth + 1, mockRankingService.evaluateCompleteness(stacCollectionModel));
         verify(mockRankingService, times(1)).evaluateCompleteness(stacCollectionModel);
     }
 }

--- a/indexer/src/test/resources/canned/associated/self.json
+++ b/indexer/src/test/resources/canned/associated/self.json
@@ -34,7 +34,7 @@
     ]
   },
   "summaries": {
-    "score": 79,
+    "score": 85,
     "status": "onGoing",
     "credits": [
       "Australia’s Integrated Marine Observing System (IMOS) is enabled by the National Collaborative Research Infrastructure Strategy (NCRIS). It is operated by a consortium of institutions as an unincorporated joint venture, with the University of Tasmania as Lead Agent.",

--- a/indexer/src/test/resources/canned/sample4_stac.json
+++ b/indexer/src/test/resources/canned/sample4_stac.json
@@ -28,7 +28,7 @@
     ]
   },
   "summaries": {
-    "score": 72,
+    "score": 78,
     "status": "completed",
     "credits": [
       "Australian Climate Change Science Program",

--- a/indexer/src/test/resources/canned/sample5_stac.json
+++ b/indexer/src/test/resources/canned/sample5_stac.json
@@ -6,7 +6,7 @@
     "temporal" : [ [ "2010-01-21T01:00:00Z", "2017-03-27T12:59:59Z" ], [ "2010-01-21T01:00:00Z", "2017-03-27T12:59:59Z" ] ]
   },
   "summaries" : {
-    "score" : 66,
+    "score" : 71,
     "status" : "completed",
     "credits" : [ "Australia’s Integrated Marine Observing System (IMOS) is enabled by the National Collaborative Research Infrastructure Strategy (NCRIS). It is operated by a consortium of institutions as an unincorporated joint venture, with the University of Tasmania as Lead Agent.", "The University of Western Australia (UWA)" ],
     "scope" : {

--- a/indexer/src/test/resources/canned/sample6_stac.json
+++ b/indexer/src/test/resources/canned/sample6_stac.json
@@ -28,7 +28,7 @@
     ]
   },
   "summaries": {
-    "score": 100,
+    "score": 106,
     "status": "completed",
     "credits": [
       "Data collected on the Marine National Facility (MNF) RV Investigator voyage IN2024_V01.",

--- a/indexer/src/test/resources/canned/sample7_stac.json
+++ b/indexer/src/test/resources/canned/sample7_stac.json
@@ -6,7 +6,7 @@
     "temporal" : [ [ "2021-09-30T14:00:00Z", "2022-12-31T12:59:59Z" ], [ "2021-09-30T14:00:00Z", "2022-12-31T12:59:59Z" ] ]
   },
   "summaries" : {
-    "score" : 70,
+    "score" : 75,
     "status" : "completed",
     "credits" : [ "This data was collected by the 'Field integrated testing project' of EcoRRAP. We thank all team members, students, and volunteers for their efforts.", "The Reef Restoration and Adaptation Program is funded by the partnership between the Australian Government’s Reef Trust and the Great Barrier Reef Foundation." ],
     "scope" : {


### PR DESCRIPTION
We add a count to the score so that the more the fields the record contains, the higher the score it receive. 