### PR TITLE
Force single version of index docs

### DIFF
--- a/indexer/src/main/java/au/org/aodn/esindexer/service/IndexServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/IndexServiceImpl.java
@@ -89,6 +89,9 @@ public abstract class IndexServiceImpl implements IndexService {
                 bulkRequest.operations(op -> op
                         .index(idx -> idx
                                 .id(id)
+                                // Force to write to a single version, we do not need to keep history for now, it should avoid system
+                                // growth fast
+                                .version(1L)
                                 .index(indexName)
                                 .document(item)
                         )


### PR DESCRIPTION
Force to use single version to avoid elastic growth and become slow, it is an experiment to see if change help