### PR TITLE
update gn4 elasticsearch image to test version

### DIFF
--- a/indexer/src/test/resources/compose-gn4-test.yml
+++ b/indexer/src/test/resources/compose-gn4-test.yml
@@ -3,7 +3,7 @@
 # your debug easier.
 services:
   setup:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.3
     user: "1000"
     command: >
       bash -c '
@@ -14,7 +14,7 @@ services:
       '
 
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.3
     environment:
       - ES_JAVA_OPTS=-Xms1g -Xmx2g
       - ELASTIC_PASSWORD=changeme
@@ -31,7 +31,7 @@ services:
       retries: 120
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.11.3
+    image: docker.elastic.co/kibana/kibana:8.13.3
     environment:
       - ELASTICSEARCH_HOSTS=http://elastic:9200
       - ELASTICSEARCH_USERNAME=kibana_system


### PR DESCRIPTION
It's a hotfix for build test failed issue, in the near future, we need to update elastic-java version to `8.19.10` to align with production.