### PR TITLE
feature/7786-update-internal-ranking-score

### DIFF
--- a/indexer/src/main/java/au/org/aodn/esindexer/service/RankingServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/RankingServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 
 import au.org.aodn.stac.model.StacCollectionModel;
 
+import static au.org.aodn.esindexer.utils.CommonUtils.safeGet;
+
 @Slf4j
 @Service
 public class RankingServiceImpl implements RankingService {
@@ -86,7 +88,7 @@ public class RankingServiceImpl implements RankingService {
             count++;
         }
         // Lineage
-        if (stacCollectionModel.getSummaries() != null && stacCollectionModel.getSummaries().getStatement() != null) {
+        if (safeGet(() -> stacCollectionModel.getSummaries().getStatement()).isPresent()) {
             log.debug("Lineage found");
             total += lineageWeigth;
             count++;
@@ -125,10 +127,9 @@ public class RankingServiceImpl implements RankingService {
             count++;
         }
         // IMOS record dataset_group = ["IMOS"]
-        if (stacCollectionModel.getSummaries() != null
-                && stacCollectionModel.getSummaries().getDatasetGroup() != null
-                && stacCollectionModel.getSummaries().getDatasetGroup().size() == 1
-                && "IMOS".equalsIgnoreCase(stacCollectionModel.getSummaries().getDatasetGroup().get(0))) {
+        if (safeGet(() -> stacCollectionModel.getSummaries().getDatasetGroup())
+                .filter(g -> g.size() == 1 && "IMOS".equalsIgnoreCase(g.get(0)))
+                .isPresent()) {
             log.debug("IMOS owned record");
             total += imosWeigth;
         }
@@ -144,14 +145,13 @@ public class RankingServiceImpl implements RankingService {
             log.debug("Record has downloadable links");
             total += downloadableWeigth;
         }
-
         // Penalty for superseded record: status equals superseded / deprecated / obsolete
-        if (stacCollectionModel.getSummaries() != null
-                && stacCollectionModel.getSummaries().getStatus() != null) {
-            String status = stacCollectionModel.getSummaries().getStatus().toLowerCase();
-            if (status.contains("superseded") || status.contains("deprecated") || status.contains("obsolete") || status.contains("historicalarchive")) {
-                total += supersededPenalty;
-            }
+        if (safeGet(() -> stacCollectionModel.getSummaries().getStatus())
+                .map(String::toLowerCase)
+                .filter(s -> s.contains("superseded") || s.contains("deprecated")
+                        || s.contains("obsolete")   || s.contains("historicalarchive"))
+                .isPresent()) {
+            total += supersededPenalty;
         }
 
         // The more field exist, the higher the mark

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/RankingServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/RankingServiceImpl.java
@@ -1,6 +1,5 @@
 package au.org.aodn.esindexer.service;
 
-import au.org.aodn.stac.model.RelationType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/RankingServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/RankingServiceImpl.java
@@ -1,5 +1,6 @@
 package au.org.aodn.esindexer.service;
 
+import au.org.aodn.stac.model.RelationType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,18 @@ public class RankingServiceImpl implements RankingService {
 
     @Value("${app.ranking.link.maxWeight:20}")
     protected int linkMaxWeigth;
+
+    @Value("${app.ranking.imos.weight:10}")
+    protected int imosWeigth;
+
+    @Value("${app.ranking.downloadable.weight:10}")
+    protected int downloadableWeigth;
+
+    @Value("${app.ranking.codownload.weight:20}")
+    protected int cloudOptimizedWeigth;
+
+    @Value("${app.ranking.superseded.penalty:-10}")
+    protected int supersededPenalty;
 
     public Integer evaluateCompleteness(StacCollectionModel stacCollectionModel) {
         int total = 0;
@@ -112,6 +125,36 @@ public class RankingServiceImpl implements RankingService {
             }
             count++;
         }
+        // IMOS record dataset_group = ["IMOS"]
+        if (stacCollectionModel.getSummaries() != null
+                && stacCollectionModel.getSummaries().getDatasetGroup() != null
+                && stacCollectionModel.getSummaries().getDatasetGroup().size() == 1
+                && "IMOS".equalsIgnoreCase(stacCollectionModel.getSummaries().getDatasetGroup().get(0))) {
+            log.debug("IMOS owned record");
+            total += imosWeigth;
+        }
+        // Cloud-optimised download service: assets populated means cloud-optimised index exists
+        if (stacCollectionModel.getAssets() != null && !stacCollectionModel.getAssets().isEmpty()) {
+            log.debug("Record has cloud optimised link");
+            total += cloudOptimizedWeigth;
+        }
+        // Has downloadable links (this will include WFS download)
+        if (stacCollectionModel.getLinks() != null
+                && stacCollectionModel.getLinks().stream().anyMatch(link ->
+                link.getAiRole() != null && link.getAiRole().contains("download"))) {
+            log.debug("Record has downloadable links");
+            total += downloadableWeigth;
+        }
+
+        // Penalty for superseded record: status equals superseded / deprecated / obsolete
+        if (stacCollectionModel.getSummaries() != null
+                && stacCollectionModel.getSummaries().getStatus() != null) {
+            String status = stacCollectionModel.getSummaries().getStatus().toLowerCase();
+            if (status.contains("superseded") || status.contains("deprecated") || status.contains("obsolete") || status.contains("historicalarchive")) {
+                total += supersededPenalty;
+            }
+        }
+
         // The more field exist, the higher the mark
         return total + count;
     }

--- a/indexer/src/main/java/au/org/aodn/esindexer/utils/DeliveryModeUtils.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/utils/DeliveryModeUtils.java
@@ -91,11 +91,8 @@ public class DeliveryModeUtils {
         }
 
         String lowerStatus = customisedStatus.toLowerCase();
-        if (lowerStatus.equals("historicalarchive") ||
-                lowerStatus.equals("obsolete") ||
-                lowerStatus.equals("deprecated") ||
-                lowerStatus.contains("complete")
-        ) {
+        // some record has a status of 'complete' so fix the typing
+        if (lowerStatus.contains("complete")) {
             return "completed";
         }
         // some record has a status of 'on going' so check with a regex mapping

--- a/indexer/src/test/java/au/org/aodn/esindexer/service/RankingServiceIT.java
+++ b/indexer/src/test/java/au/org/aodn/esindexer/service/RankingServiceIT.java
@@ -126,7 +126,7 @@ class RankingServiceIT extends BaseTestClass {
         stacCollectionModel.setSummaries(SummariesModel.builder()
                 .datasetGroup(List.of("imos"))
                 .build());
-        assertEquals(mockRankingService.imosWeigth + 1, mockRankingService.evaluateCompleteness(stacCollectionModel));
+        assertEquals(mockRankingService.imosWeigth, mockRankingService.evaluateCompleteness(stacCollectionModel));
     }
 
     @Test
@@ -142,12 +142,18 @@ class RankingServiceIT extends BaseTestClass {
     public void testDownloadableLinks() {
         RankingServiceImpl mockRankingService = Mockito.spy(rankingService);
         List<LinkModel> links = new ArrayList<>();
-        links.add(LinkModel.builder().rel(RelationType.DATA.getValue()).href("http://example.com/data").build());
+        links.add(LinkModel.builder()
+                .rel("related")
+                .href("http://example.com/data")
+                .aiGroup("Data Access")
+                .aiRole(List.of("download"))
+                .build());
         stacCollectionModel.setLinks(links);
         // 1 link → linkMinWeigth(10) + downloadableWeigth(10) + count(1) = 21
         assertEquals(mockRankingService.linkMinWeigth + mockRankingService.downloadableWeigth + 1,
                 mockRankingService.evaluateCompleteness(stacCollectionModel));
     }
+
 
     @Test
     public void testSupersededPenalty() {
@@ -155,6 +161,7 @@ class RankingServiceIT extends BaseTestClass {
         stacCollectionModel.setSummaries(SummariesModel.builder()
                 .status("superseded")
                 .build());
-        assertEquals(-mockRankingService.supersededPenalty, mockRankingService.evaluateCompleteness(stacCollectionModel));
+        // penalty -10
+        assertEquals(mockRankingService.supersededPenalty, mockRankingService.evaluateCompleteness(stacCollectionModel));
     }
 }

--- a/indexer/src/test/java/au/org/aodn/esindexer/service/RankingServiceIT.java
+++ b/indexer/src/test/java/au/org/aodn/esindexer/service/RankingServiceIT.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -117,5 +118,43 @@ class RankingServiceIT extends BaseTestClass {
         // assert, because only 1 field found, so we add 1 to the weight
         assertEquals(mockRankingService.lineageWeigth + 1, mockRankingService.evaluateCompleteness(stacCollectionModel));
         verify(mockRankingService, times(1)).evaluateCompleteness(stacCollectionModel);
+    }
+
+    @Test
+    public void testImosOwnedRecord() {
+        RankingServiceImpl mockRankingService = Mockito.spy(rankingService);
+        stacCollectionModel.setSummaries(SummariesModel.builder()
+                .datasetGroup(List.of("imos"))
+                .build());
+        assertEquals(mockRankingService.imosWeigth + 1, mockRankingService.evaluateCompleteness(stacCollectionModel));
+    }
+
+    @Test
+    public void testCloudOptimisedDownloadService() {
+        RankingServiceImpl mockRankingService = Mockito.spy(rankingService);
+        stacCollectionModel.setAssets(Map.of(
+                "cloud-optimised.parquet", AssetModel.builder().role(AssetModel.Role.SUMMARY).build()
+        ));
+        assertEquals(mockRankingService.cloudOptimizedWeigth, mockRankingService.evaluateCompleteness(stacCollectionModel));
+    }
+
+    @Test
+    public void testDownloadableLinks() {
+        RankingServiceImpl mockRankingService = Mockito.spy(rankingService);
+        List<LinkModel> links = new ArrayList<>();
+        links.add(LinkModel.builder().rel(RelationType.DATA.getValue()).href("http://example.com/data").build());
+        stacCollectionModel.setLinks(links);
+        // 1 link → linkMinWeigth(10) + downloadableWeigth(10) + count(1) = 21
+        assertEquals(mockRankingService.linkMinWeigth + mockRankingService.downloadableWeigth + 1,
+                mockRankingService.evaluateCompleteness(stacCollectionModel));
+    }
+
+    @Test
+    public void testSupersededPenalty() {
+        RankingServiceImpl mockRankingService = Mockito.spy(rankingService);
+        stacCollectionModel.setSummaries(SummariesModel.builder()
+                .status("superseded")
+                .build());
+        assertEquals(-mockRankingService.supersededPenalty, mockRankingService.evaluateCompleteness(stacCollectionModel));
     }
 }

--- a/indexer/src/test/java/au/org/aodn/esindexer/utils/DeliveryModeUtilsTest.java
+++ b/indexer/src/test/java/au/org/aodn/esindexer/utils/DeliveryModeUtilsTest.java
@@ -8,14 +8,6 @@ public class DeliveryModeUtilsTest {
 
     @Test
     public void testNormaliseStatusWithCustomisedStatus() {
-        // example: https://catalogue.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/06bf0e30-2ae3-11dd-a735-00188b4c0af8
-        String historicalArchiveInput = "historicalArchive";
-        assertEquals("completed", DeliveryModeUtils.normaliseStatus(historicalArchiveInput), "historicalArchive should be normalized to completed");
-
-        // example: https://catalogue.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/e3715a57-69de-4013-b4d4-695ee5428fe4
-        String obsoleteInput = "obsolete";
-        assertEquals("completed", DeliveryModeUtils.normaliseStatus(obsoleteInput), "obsolete should be normalized to completed");
-
         // example: https://catalogue.aodn.org.au/geonetwork/srv/eng/catalog.search#/metadata/51a5b7e6-80a5-4e36-b3e2-2b558dd2b4aa
         String completeInput = "Complete";
         assertEquals("completed", DeliveryModeUtils.normaliseStatus(completeInput), "Complete should be normalized to completed");


### PR DESCRIPTION
Please feel free to try this test branch in ogc-api (https://github.com/aodn/ogcapi-java/tree/test/7786-test-internal-ranking-score). It adjusts the internal ranking score during search to demonstrate the expected behaviour. These demo below are intended to give an indication of how the updated ranking logic would behave in practice.

1. IMOS record always at the top
<img width="1691" height="632" alt="image" src="https://github.com/user-attachments/assets/ade625fc-0d0d-4030-8097-a0d051158e87" />

2. CO downloadable records above other downloadable records
<img width="1592" height="639" alt="image" src="https://github.com/user-attachments/assets/76bda6db-d779-452c-b87b-7ca94ef555e6" />

4. superseded record at the bottom
<img width="1610" height="509" alt="image" src="https://github.com/user-attachments/assets/7795f4d0-afc1-4fc4-8205-b22f0bdb17f1" />
