### PR TITLE
feature/8070-add-semantic-ingest-pipeline

### DIFF
--- a/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabDto.java
+++ b/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabDto.java
@@ -18,4 +18,17 @@ public class VocabDto {
 
     @JsonProperty("organisation_vocab")
     VocabModel organisationVocabModel;
+
+    /**
+     * Computed property serialized into every indexed doc so the {@code concept_semantic} semantic_text
+     * field is populated automatically (bulk index serializes this DTO). {@code @JsonInclude(NON_NULL)}
+     * omits it when there is no text to embed.
+     */
+    @JsonProperty("concept_semantic")
+    public String getConceptSemantic() {
+        VocabModel m = parameterVocabModel != null ? parameterVocabModel
+                     : platformVocabModel  != null ? platformVocabModel
+                     : organisationVocabModel;
+        return m == null ? null : m.toConceptText();
+    }
 }

--- a/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabDto.java
+++ b/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabDto.java
@@ -20,9 +20,8 @@ public class VocabDto {
     VocabModel organisationVocabModel;
 
     /**
-     * Computed property serialized into every indexed doc so the {@code concept_semantic} semantic_text
-     * field is populated automatically (bulk index serializes this DTO). {@code @JsonInclude(NON_NULL)}
-     * omits it when there is no text to embed.
+     * Computed property serialized into every indexed doc so the semantic_text
+     * field is populated automatically (bulk index serializes this DTO).
      */
     @JsonProperty("concept_semantic")
     public String getConceptSemantic() {

--- a/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabDto.java
+++ b/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabDto.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Objects;
+
 @Data
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -20,14 +23,29 @@ public class VocabDto {
     VocabModel organisationVocabModel;
 
     /**
-     * Computed property serialized into every indexed doc so the semantic_text
-     * field is populated automatically (bulk index serializes this DTO).
+     * Each entry in the list is the combination text from the level-2 label title, level-2 label description, and the leaf label title of level-2 label.
      */
     @JsonProperty("concept_semantic")
-    public String getConceptSemantic() {
-        VocabModel m = parameterVocabModel != null ? parameterVocabModel
-                     : platformVocabModel  != null ? platformVocabModel
-                     : organisationVocabModel;
-        return m == null ? null : m.toConceptText();
+    public List<String> getConceptSemantic() {
+        VocabModel model = parameterVocabModel != null ? parameterVocabModel
+                         : platformVocabModel  != null ? platformVocabModel
+                         : organisationVocabModel;
+
+        if (model == null) {
+            return null;
+        }
+
+        List<String> conceptTexts = model.getNarrower() == null
+                ? List.of()
+                : model.getNarrower().stream()
+                        .map(VocabModel::toConceptText)
+                        .filter(Objects::nonNull)
+                        .toList();
+
+        if (conceptTexts.isEmpty()) {
+            String ownConceptText = model.toConceptText();
+            return ownConceptText == null ? null : List.of(ownConceptText);
+        }
+        return conceptTexts;
     }
 }

--- a/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabModel.java
+++ b/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabModel.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Builder
 @Getter
@@ -29,4 +31,19 @@ public class VocabModel {
     protected List<VocabModel> broader;
     protected List<VocabModel> narrower;
     protected String version;
+
+    /**
+     * Concat the concept text so that helps to its semantic representation. Include all text for representing a vocab.
+     */
+    public String toConceptText() {
+        List<String> parts = new ArrayList<>();
+        if (label != null)        parts.add(label);
+        if (displayLabel != null) parts.add(displayLabel);
+        if (altLabels != null)    parts.addAll(altLabels);
+        if (hiddenLabels != null) parts.addAll(hiddenLabels);
+        if (definition != null)   parts.add(definition);
+        if (narrower != null)     narrower.stream()
+                .map(VocabModel::getLabel).filter(Objects::nonNull).forEach(parts::add);
+        return parts.isEmpty() ? null : String.join(". ", parts);
+    }
 }

--- a/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabModel.java
+++ b/ardcvocabs/src/main/java/au/org/aodn/ardcvocabs/model/VocabModel.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 @Builder
 @Getter
@@ -36,14 +36,20 @@ public class VocabModel {
      * Concat the concept text so that helps to its semantic representation. Include all text for representing a vocab.
      */
     public String toConceptText() {
-        List<String> parts = new ArrayList<>();
-        if (label != null)        parts.add(label);
-        if (displayLabel != null) parts.add(displayLabel);
-        if (altLabels != null)    parts.addAll(altLabels);
-        if (hiddenLabels != null) parts.addAll(hiddenLabels);
-        if (definition != null)   parts.add(definition);
-        if (narrower != null)     narrower.stream()
-                .map(VocabModel::getLabel).filter(Objects::nonNull).forEach(parts::add);
+        List<String> parts = Stream.of(
+                        Stream.of(label, displayLabel),
+                        stream(altLabels),
+                        stream(hiddenLabels),
+                        Stream.of(definition),
+                        stream(narrower).map(VocabModel::getLabel))
+                .flatMap(s -> s)
+                .filter(Objects::nonNull)
+                .toList();
+
         return parts.isEmpty() ? null : String.join(". ", parts);
+    }
+
+    private static <T> Stream<T> stream(List<T> values) {
+        return values == null ? Stream.empty() : values.stream();
     }
 }

--- a/ardcvocabs/src/test/java/au/org/aodn/ardcvocabs/model/VocabDtoTest.java
+++ b/ardcvocabs/src/test/java/au/org/aodn/ardcvocabs/model/VocabDtoTest.java
@@ -1,0 +1,144 @@
+package au.org.aodn.ardcvocabs.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The concept_semantic field is built per narrower (level-2) concept, not from the top-level
+ * (level-1) category, so that each level-2 concept gets its own semantic representation.
+ */
+public class VocabDtoTest {
+
+    protected ObjectMapper mapper = new ObjectMapper();
+
+    protected VocabModel leaf(String label) {
+        return VocabModel.builder().label(label).build();
+    }
+
+    /**
+     * Chemical (level 1)
+     *   |- Nutrient (level 2, full label set)
+     *   |    |- Nitrate (leaf, itself has a level-4 child that must be ignored)
+     *   |    |- Phosphate (leaf)
+     *   |- Carbon (level 2, label + definition only)
+     *        |- DIC (leaf)
+     */
+    protected VocabModel buildTopLevelVocab() {
+        VocabModel nitrate = VocabModel.builder()
+                .label("Nitrate")
+                .narrower(List.of(leaf("Nitrate as NOx")))
+                .build();
+
+        VocabModel nutrient = VocabModel.builder()
+                .label("Nutrient")
+                .displayLabel("Nutrient (chemical)")
+                .altLabels(List.of("Nutrients"))
+                .hiddenLabels(List.of("nutrint"))
+                .definition("Dissolved inorganic nutrients in seawater")
+                .narrower(List.of(nitrate, leaf("Phosphate")))
+                .build();
+
+        VocabModel carbon = VocabModel.builder()
+                .label("Carbon")
+                .definition("Carbon species in seawater")
+                .narrower(List.of(leaf("DIC")))
+                .build();
+
+        return VocabModel.builder()
+                .label("Chemical")
+                .definition("Chemical category")
+                .narrower(List.of(nutrient, carbon))
+                .build();
+    }
+
+    @Test
+    public void verifyConceptSemanticIsBuiltPerNarrowerConcept() {
+        VocabDto dto = VocabDto.builder().parameterVocabModel(buildTopLevelVocab()).build();
+
+        assertEquals(
+                List.of(
+                        "Nutrient. Nutrient (chemical). Nutrients. nutrint. Dissolved inorganic nutrients in seawater. Nitrate. Phosphate",
+                        "Carbon. Carbon species in seawater. DIC"
+                ),
+                dto.getConceptSemantic(),
+                "One entry per level-2 concept, each with its own labels, definition and leaf labels"
+        );
+    }
+
+    @Test
+    public void verifyTopLevelLabelIsNotIncluded() {
+        VocabDto dto = VocabDto.builder().parameterVocabModel(buildTopLevelVocab()).build();
+
+        dto.getConceptSemantic().forEach(conceptText ->
+                assertFalse(conceptText.contains("Chemical"),
+                        "Level-1 category text must not leak into the level-2 entries: " + conceptText));
+    }
+
+    @Test
+    public void verifyOnlyDirectLeafLabelsAreIncluded() {
+        VocabDto dto = VocabDto.builder().parameterVocabModel(buildTopLevelVocab()).build();
+
+        assertFalse(dto.getConceptSemantic().get(0).contains("Nitrate as NOx"),
+                "Descendants below the leaf level must not be included");
+    }
+
+    @Test
+    public void verifyFlatVocabFallsBackToItsOwnConceptText() {
+        VocabModel flatVocab = VocabModel.builder()
+                .label("Australian Institute of Marine Science")
+                .altLabels(List.of("AIMS"))
+                .definition("A marine research agency")
+                .build();
+
+        VocabDto dto = VocabDto.builder().organisationVocabModel(flatVocab).build();
+
+        assertEquals(
+                List.of("Australian Institute of Marine Science. AIMS. A marine research agency"),
+                dto.getConceptSemantic(),
+                "A vocab with no narrower concepts must still be semantically searchable"
+        );
+    }
+
+    @Test
+    public void verifyNarrowerConceptsWithoutAnyTextAreSkipped() {
+        VocabModel topLevel = VocabModel.builder()
+                .label("Platform")
+                .narrower(List.of(VocabModel.builder().build(), leaf("Mooring")))
+                .build();
+
+        VocabDto dto = VocabDto.builder().platformVocabModel(topLevel).build();
+
+        assertEquals(List.of("Mooring"), dto.getConceptSemantic());
+    }
+
+    @Test
+    public void verifyConceptSemanticIsNullWhenNoVocabModelIsSet() {
+        assertNull(VocabDto.builder().build().getConceptSemantic());
+    }
+
+    @Test
+    public void verifyConceptSemanticIsSerialisedAsAnArray() {
+        VocabDto dto = VocabDto.builder().parameterVocabModel(buildTopLevelVocab()).build();
+
+        JsonNode node = mapper.valueToTree(dto).get("concept_semantic");
+
+        assertNotNull(node, "concept_semantic must be serialised into the indexed doc");
+        assertTrue(node.isArray(), "concept_semantic must be an array so ES embeds each level-2 concept separately");
+        assertEquals(2, node.size());
+    }
+
+    @Test
+    public void verifyConceptSemanticIsOmittedWhenNull() {
+        assertNull(mapper.valueToTree(VocabDto.builder().build()).get("concept_semantic"),
+                "NON_NULL keeps an empty concept_semantic out of the indexed doc");
+    }
+}

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/ElasticSearchIndexService.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/ElasticSearchIndexService.java
@@ -18,6 +18,7 @@ import co.elastic.clients.elasticsearch.indices.GetAliasResponse;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -33,6 +34,14 @@ public class ElasticSearchIndexService {
 
     @Autowired
     ElasticsearchClient portalElasticsearchClient;
+
+    /*
+        semantic_text fields need the licensed `inference` feature. Off by default so a basic-licence
+        cluster (integration tests, local dev) still gets a usable index - see
+        JsonUtil.stripSemanticTextFields. Turn it on for the edge/prod clusters, which are licensed.
+    */
+    @Value("${elasticsearch.semantic.enabled:false}")
+    boolean semanticEnabled;
 
     // Naming below follows the blue-green deployment pattern which is the pattern we are using for index updates and are recommended naming convention.
     private static final String indexSuffix1 = "-blue";
@@ -85,7 +94,7 @@ public class ElasticSearchIndexService {
         log.info("Reading index schema definition from JSON file: {}", indexMappingFile);
 
         // https://www.baeldung.com/java-classpath-resource-cannot-be-opened#resources
-        try (Reader reader = JsonUtil.createJsonStream(indexMappingFile, indexSettings)) {
+        try (Reader reader = JsonUtil.createJsonStream(indexMappingFile, indexSettings, semanticEnabled)) {
             log.info("Creating index: {}", indexName);
             CreateIndexRequest req = CreateIndexRequest.of(b -> b
                     .index(indexName)

--- a/indexer/src/main/resources/application-dev.yaml
+++ b/indexer/src/main/resources/application-dev.yaml
@@ -15,6 +15,8 @@ elasticsearch:
     name: dev_portal_records
   acronyms:
     name: portal-acronyms-dev
+  semantic:
+    enabled: false
   serverUrl: https://dev-discovery-index.es.ap-southeast-2.aws.found.io
   apiKey: sample-api-key
 

--- a/indexer/src/main/resources/application-edge.yaml
+++ b/indexer/src/main/resources/application-edge.yaml
@@ -12,6 +12,8 @@ app:
 elasticsearch:
   acronyms:
     name: portal-acronyms-edge
+  semantic:
+    enabled: true
 
 management:
   endpoints:

--- a/indexer/src/main/resources/application-production.yaml
+++ b/indexer/src/main/resources/application-production.yaml
@@ -11,3 +11,5 @@ management:
 elasticsearch:
   acronyms:
     name: portal-acronyms-production
+  semantic:
+    enabled: true

--- a/indexer/src/main/resources/application-staging.yaml
+++ b/indexer/src/main/resources/application-staging.yaml
@@ -11,3 +11,5 @@ management:
 elasticsearch:
   acronyms:
     name: portal-acronyms-staging
+  semantic:
+    enabled: true

--- a/indexer/src/main/resources/application.yaml
+++ b/indexer/src/main/resources/application.yaml
@@ -55,6 +55,11 @@ elasticsearch:
     name: portal-acronyms
     manual:
       - "nrmn => national reef monitoring network"
+  # semantic_text fields (concept_semantic, description_semantic) need the licensed `inference`
+  # feature. Left off here so a basic-licence cluster still builds a working index - the edge/prod
+  # deployments, which are licensed, switch it on.
+  semantic:
+    enabled: false
 
 aws:
   region: ap-southeast-2

--- a/indexer/src/main/resources/application.yaml
+++ b/indexer/src/main/resources/application.yaml
@@ -55,9 +55,8 @@ elasticsearch:
     name: portal-acronyms
     manual:
       - "nrmn => national reef monitoring network"
-  # semantic_text fields (concept_semantic, description_semantic) need the licensed `inference`
-  # feature. Left off here so a basic-licence cluster still builds a working index - the edge/prod
-  # deployments, which are licensed, switch it on.
+  # semantic_text fields (concept_semantic, description_semantic) need the licensed `inference` feature.
+  # Switch it on for edge/staging/production.
   semantic:
     enabled: false
 

--- a/indexer/src/test/resources/application-test.yaml
+++ b/indexer/src/test/resources/application-test.yaml
@@ -24,6 +24,10 @@ elasticsearch:
     enableRefreshDelay: "false"
   query:
     pageSize: 4
+  # the test container runs a basic licence, which has no `inference` - keep semantic_text out of the
+  # mappings or every indexed document is rejected
+  semantic:
+    enabled: false
   acronyms:
     name: portal-acronyms-test
     manual:

--- a/stacmodel/src/main/java/au/org/aodn/stac/util/JsonUtil.java
+++ b/stacmodel/src/main/java/au/org/aodn/stac/util/JsonUtil.java
@@ -1,18 +1,27 @@
 package au.org.aodn.stac.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class JsonUtil {
 
     protected final static ObjectMapper mapper = new ObjectMapper();
+
+    protected final static String SEMANTIC_TEXT = "semantic_text";
 
     public static <T> String toJsonString(T instance) {
         try{
@@ -23,6 +32,14 @@ public class JsonUtil {
     }
 
     public static Reader createJsonStream(String indexMappingFile, Map<String, String> param) throws IOException {
+        return createJsonStream(indexMappingFile, param, true);
+    }
+
+    /**
+     * @param semanticEnabled when false, every semantic_text field is stripped from the mapping
+     *                        before the index is created.
+     */
+    public static Reader createJsonStream(String indexMappingFile, Map<String, String> param, boolean semanticEnabled) throws IOException {
         try (InputStream inputStream = JsonUtil.class.getResourceAsStream("/schema/" + indexMappingFile)) {
             if (inputStream != null) {
                 String json = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
@@ -31,9 +48,82 @@ public class JsonUtil {
                         json = json.replace("${" + entry.getKey() + "}", entry.getValue());
                     }
                 }
+                if (!semanticEnabled) {
+                    json = stripSemanticTextFields(json);
+                }
                 return new StringReader(json);
             }
         }
         return null;
+    }
+
+    /**
+     * Removes every semantic_text field from an index mapping, together with any copy_to
+     * Elasticsearch inference only valid in certain license, in dev and test env, it is not avaiable.
+     * So stripping the field keeps the same schema file usable on both licensed and unlicensed clusters
+     * @param json the raw index mapping JSON
+     * @return the mapping with no semantic fields, or the input unchanged when it had none
+     */
+    public static String stripSemanticTextFields(String json) throws IOException {
+        JsonNode root = mapper.readTree(json);
+
+        Set<String> removed = new HashSet<>();
+        removeSemanticTextFields(root, removed);
+        if (removed.isEmpty()) {
+            return json;
+        }
+
+        removeCopyToTargets(root, removed);
+        return mapper.writeValueAsString(root);
+    }
+
+    /**
+     * Walks every property block in schema - mappings nest them under object and nested fields - removing
+     * the fields typed semantic_text and collecting their names.
+     */
+    private static void removeSemanticTextFields(JsonNode node, Set<String> removed) {
+        JsonNode properties = node.get("properties");
+        if (properties instanceof ObjectNode props) {
+            List<String> semanticFields = new ArrayList<>();
+            props.fields().forEachRemaining(field -> {
+                JsonNode type = field.getValue().get("type");
+                if (type != null && SEMANTIC_TEXT.equals(type.asText())) {
+                    semanticFields.add(field.getKey());
+                }
+            });
+            semanticFields.forEach(name -> {
+                props.remove(name);
+                removed.add(name);
+            });
+        }
+        node.forEach(child -> removeSemanticTextFields(child, removed));
+    }
+
+    /**
+     * Drops copy_to references to fields that no longer exist, this copy_to is used for mapping a text field to a
+     * semantic_text field.
+     */
+    private static void removeCopyToTargets(JsonNode node, Set<String> removed) {
+        if (node instanceof ObjectNode object) {
+            JsonNode copyTo = object.get("copy_to");
+            if (copyTo != null && copyTo.isTextual() && removed.contains(copyTo.asText())) {
+                object.remove("copy_to");
+            }
+            else if (copyTo != null && copyTo.isArray()) {
+                ArrayNode kept = mapper.createArrayNode();
+                copyTo.forEach(target -> {
+                    if (!removed.contains(target.asText())) {
+                        kept.add(target);
+                    }
+                });
+                if (kept.isEmpty()) {
+                    object.remove("copy_to");
+                }
+                else {
+                    object.set("copy_to", kept);
+                }
+            }
+        }
+        node.forEach(child -> removeCopyToTargets(child, removed));
     }
 }

--- a/stacmodel/src/main/resources/schema/portal_records_index_schema.json
+++ b/stacmodel/src/main/resources/schema/portal_records_index_schema.json
@@ -160,12 +160,17 @@
       },
       "description": {
         "type": "text",
+        "copy_to": "description_semantic",
         "fields": {
           "synonyms": {
             "type": "text",
             "search_analyzer": "acronym_search_analyser"
           }
         }
+      },
+      "description_semantic": {
+        "type": "semantic_text",
+        "inference_id": ".elser-2-elasticsearch"
       },
       "license": {
         "type": "keyword",

--- a/stacmodel/src/main/resources/schema/vocabs_index_schema.json
+++ b/stacmodel/src/main/resources/schema/vocabs_index_schema.json
@@ -2,6 +2,10 @@
   "mappings": {
     "dynamic": true,
     "properties": {
+      "concept_semantic": {
+        "type": "semantic_text",
+        "inference_id": ".elser-2-elasticsearch"
+      },
       "parameter_vocab": {
         "properties": {
           "label": {

--- a/stacmodel/src/test/java/au/org/aodn/stac/util/JsonUtilTest.java
+++ b/stacmodel/src/test/java/au/org/aodn/stac/util/JsonUtilTest.java
@@ -79,4 +79,70 @@ public class JsonUtilTest {
             assertEquals("acronym_search_analyser", desc.path("fields").path("synonyms").path("search_analyzer").asText());
         }
     }
+
+    /**
+     * semantic_text needs the licensed `inference` feature; on a basic-licence cluster an index carrying
+     * one rejects every document written to it. With semantic disabled the schema must come back with no
+     * semantic field and no dangling copy_to, while everything else stays intact.
+     */
+    @Test
+    public void verifySemanticFieldsStrippedWhenDisabled() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        try (Reader r = JsonUtil.createJsonStream("portal_records_index_schema.json",
+                Map.of("portal-acronyms", "it-synset"), false)) {
+            assertNotNull(r);
+            JsonNode props = mapper.readTree(new BufferedReader(r).lines().collect(Collectors.joining("\n")))
+                    .path("mappings").path("properties");
+
+            assertTrue(props.path("description_semantic").isMissingNode(),
+                    "description_semantic must be gone when semantic is disabled");
+            assertFalse(props.path("description").has("copy_to"),
+                    "description.copy_to must go with the field it fed, or ES rejects the mapping");
+
+            // untouched neighbours
+            assertEquals("text", props.path("description").path("type").asText());
+            assertEquals("acronym_search_analyser",
+                    props.path("description").path("fields").path("synonyms").path("search_analyzer").asText());
+            assertEquals("keyword", props.path("parameter_vocabs").path("type").asText());
+        }
+
+        try (Reader r = JsonUtil.createJsonStream("vocabs_index_schema.json", null, false)) {
+            assertNotNull(r);
+            JsonNode props = mapper.readTree(new BufferedReader(r).lines().collect(Collectors.joining("\n")))
+                    .path("mappings").path("properties");
+
+            assertTrue(props.path("concept_semantic").isMissingNode(),
+                    "concept_semantic must be gone when semantic is disabled");
+            assertTrue(props.has("parameter_vocab"), "the rest of the vocabs mapping must survive");
+            assertTrue(props.has("platform_vocab"));
+            assertTrue(props.has("organisation_vocab"));
+        }
+    }
+
+    /**
+     * The default (and the licensed clusters) must still get the semantic fields.
+     */
+    @Test
+    public void verifySemanticFieldsKeptWhenEnabled() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        try (Reader r = JsonUtil.createJsonStream("portal_records_index_schema.json",
+                Map.of("portal-acronyms", "it-synset"))) {
+            assertNotNull(r);
+            JsonNode props = mapper.readTree(new BufferedReader(r).lines().collect(Collectors.joining("\n")))
+                    .path("mappings").path("properties");
+
+            assertEquals("semantic_text", props.path("description_semantic").path("type").asText());
+            assertEquals("description_semantic", props.path("description").path("copy_to").asText());
+        }
+
+        try (Reader r = JsonUtil.createJsonStream("vocabs_index_schema.json", null)) {
+            assertNotNull(r);
+            JsonNode props = mapper.readTree(new BufferedReader(r).lines().collect(Collectors.joining("\n")))
+                    .path("mappings").path("properties");
+
+            assertEquals("semantic_text", props.path("concept_semantic").path("type").asText());
+        }
+    }
 }


### PR DESCRIPTION
add `semantic_text` type field using Elasticsearch built-in inference endpoint `.elser-2-elasticsearch`
<img width="903" height="303" alt="image" src="https://github.com/user-attachments/assets/f93774c7-3578-4496-a0d2-e3f427408066" />

<img width="916" height="394" alt="image" src="https://github.com/user-attachments/assets/3c7486ea-b403-4861-8032-d915cfc9dc58" />

<img width="950" height="374" alt="image" src="https://github.com/user-attachments/assets/5f3364b7-cd0b-44d6-9fbf-b43b3e052eca" />


