### PR TITLE
Use batch split size upload

### DIFF
--- a/indexer/src/main/java/au/org/aodn/esindexer/controller/IndexerExtController.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/controller/IndexerExtController.java
@@ -1,7 +1,6 @@
 package au.org.aodn.esindexer.controller;
 
 import au.org.aodn.ardcvocabs.model.ArdcCurrentPaths;
-import au.org.aodn.ardcvocabs.model.VocabApiPaths;
 import au.org.aodn.ardcvocabs.model.VocabModel;
 import au.org.aodn.ardcvocabs.service.ArdcVocabService;
 import au.org.aodn.esindexer.service.VocabService;
@@ -87,9 +86,9 @@ public class IndexerExtController {
     }
 
     // this endpoint for debugging/development purposes
-    @GetMapping(path="/vocabs/populate")
+    @PostMapping(path="/vocabs/populate")
     @Operation(security = { @SecurityRequirement(name = "X-API-Key") }, description = "Populate data to the vocabs index")
-    public ResponseEntity<String> populateDataToVocabsIndex() throws IOException, ExecutionException, InterruptedException {
+    public ResponseEntity<String> populateDataToVocabsIndex() throws IOException {
         // clear existing caches
         vocabService.clearParameterVocabCache();
         vocabService.clearPlatformVocabCache();

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/IndexServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/IndexServiceImpl.java
@@ -72,25 +72,24 @@ public abstract class IndexServiceImpl implements IndexService {
                 log.debug("Bulk size usage: {}%", (roundedPercentage * 100));
 
                 // We need to split the batch into smaller size to avoid data too large error in ElasticSearch,
-                // the limit is 10mb, so to make check before document add and push batch if size is too big
+                // the limit is 10mb, so check before document add and push batch if size is too big.
                 //
-                // dataSize = 0 is init case, just in case we have a very big doc that exceed the limit
-                // and we have not add it to the bulkRequest, hardcode to 5M which should be safe,
-                // usually it is 5M - 15M
+                // dataSize = 0 is init case, just in case we have a very big doc that exceeds the limit
+                // and we have not add it to the bulkRequest yet; batch size is 5M which should be safe,
+                // usually the ES limit is 5M - 15M.
                 //
+                Optional<BulkResponse> flushed = Optional.empty();
                 if (dataSize + size > IndexServiceImpl.this.getBatchSize() && dataSize != 0) {
                     if (callback != null) {
                         callback.onProgress(String.format("Execute batch as bulk request is big enough %s", dataSize + size));
                     }
 
-                    Optional<BulkResponse> result = Optional.of(reduceResponse(proxyImpl.executeBulk(bulkRequest.build(), mapper, callback)));
+                    flushed = Optional.of(reduceResponse(proxyImpl.executeBulk(bulkRequest.build(), mapper, callback)));
 
                     dataSize = 0;
                     bulkRequest = new BulkRequest.Builder();
-
-                    return result;
                 }
-                // Add item to  bulk request to Elasticsearch
+                // Add item to bulk request (including the item that triggered a flush above)
                 bulkRequest.operations(op -> op
                         .index(idx -> idx
                                 .id(id)
@@ -110,6 +109,7 @@ public abstract class IndexServiceImpl implements IndexService {
                                     total)
                     );
                 }
+                return flushed;
             }
             return Optional.empty();
         }

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/IndexServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/IndexServiceImpl.java
@@ -24,6 +24,12 @@ import java.util.function.Function;
 public abstract class IndexServiceImpl implements IndexService {
 
     protected static final long DEFAULT_BACKOFF_TIME = 3000L;
+    /**
+     * Serializes bulk writes across all IndexServiceImpl subclasses (e.g. metadata + vocabs)
+     * so concurrent callers do not hit Elasticsearch with overlapping bulk requests.
+     */
+    private static final Object BULK_EXECUTE_LOCK = new Object();
+
     protected ElasticsearchClient elasticClient;
     protected ObjectMapper indexerObjectMapper;
 
@@ -172,52 +178,54 @@ public abstract class IndexServiceImpl implements IndexService {
     )
     @Override
     public <T> BulkResponse executeBulk(BulkRequest bulkRequest, Function<BulkResponseItem, Optional<T>> mapper, IndexerMetadataService.Callback callback) throws IOException, HttpServerErrorException.ServiceUnavailable {
-        try {
-            // Keep retry until success
-            BulkResponse result = elasticClient.bulk(bulkRequest);
+        // One bulk at a time process-wide (metadata, vocabs, etc. share this lock)
+        synchronized (BULK_EXECUTE_LOCK) {
+            try {
+                // Keep retry until success
+                BulkResponse result = elasticClient.bulk(bulkRequest);
 
-            // Flush after insert, otherwise you need to wait for next auto-refresh. It is
-            // especially a problem with autotest, where assert happens very fast.
-            elasticClient.indices().refresh();
+                // Flush after insert, otherwise you need to wait for next auto-refresh. It is
+                // especially a problem with autotest, where assert happens very fast.
+                elasticClient.indices().refresh();
 
-            // Report status if success
-            if(callback != null) {
-                callback.onProgress(reduceResponse(result));
-            }
-
-            // Log errors, if any
-            if (!result.items().isEmpty()) {
-                if (result.errors()) {
-                    log.error("Bulk load have errors? {}", true);
+                // Report status if success
+                if (callback != null) {
+                    callback.onProgress(reduceResponse(result));
                 }
-                for (BulkResponseItem item : result.items()) {
-                    if (item.error() != null) {
-                        Optional<T> i = mapper.apply(item);
-                        i.ifPresent(a -> {
-                            try {
-                                log.error("UUID {} {} {} {}",
-                                        item.id(),
-                                        item.error().reason(),
-                                        item.error().causedBy(),
-                                        indexerObjectMapper
-                                                .writerWithDefaultPrettyPrinter()
-                                                .writeValueAsString(a)
-                                );
-                            } catch (JsonProcessingException e) {
-                                log.error("Fail to convert item with json mapper, {}", item.id());
-                            }
-                        });
+
+                // Log errors, if any
+                if (!result.items().isEmpty()) {
+                    if (result.errors()) {
+                        log.error("Bulk load have errors? {}", true);
+                    }
+                    for (BulkResponseItem item : result.items()) {
+                        if (item.error() != null) {
+                            Optional<T> i = mapper.apply(item);
+                            i.ifPresent(a -> {
+                                try {
+                                    log.error("UUID {} {} {} {}",
+                                            item.id(),
+                                            item.error().reason(),
+                                            item.error().causedBy(),
+                                            indexerObjectMapper
+                                                    .writerWithDefaultPrettyPrinter()
+                                                    .writeValueAsString(a)
+                                    );
+                                } catch (JsonProcessingException e) {
+                                    log.error("Fail to convert item with json mapper, {}", item.id());
+                                }
+                            });
+                        }
                     }
                 }
+                return result;
+            } catch (Exception e) {
+                // Report status if not success, this help to keep connection
+                if (callback != null) {
+                    callback.onProgress("Exception on bulk save, will retry : " + e.getMessage());
+                }
+                throw e;
             }
-            return result;
-        }
-        catch(Exception e) {
-            // Report status if not success, this help to keep connection
-            if(callback != null) {
-                callback.onProgress("Exception on bulk save, will retry : " + e.getMessage());
-            }
-            throw e;
         }
     }
 

--- a/indexer/src/main/java/au/org/aodn/esindexer/service/VocabServiceImpl.java
+++ b/indexer/src/main/java/au/org/aodn/esindexer/service/VocabServiceImpl.java
@@ -10,8 +10,6 @@ import au.org.aodn.stac.model.ContactsModel;
 import au.org.aodn.stac.model.ThemesModel;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
-import co.elastic.clients.elasticsearch.core.BulkRequest;
-import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.search.Hit;
@@ -20,6 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.cache.annotation.CacheEvict;
@@ -34,6 +33,7 @@ import java.util.concurrent.*;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.function.Function;
 
 import static au.org.aodn.esindexer.utils.CommonUtils.safeGet;
 
@@ -41,7 +41,7 @@ import static au.org.aodn.esindexer.utils.CommonUtils.safeGet;
 @Service
 // create and inject a stub proxy to self due to the circular reference http://bit.ly/4aFvYtt
 @Scope(proxyMode = ScopedProxyMode.TARGET_CLASS)
-public class VocabServiceImpl implements VocabService {
+public class VocabServiceImpl extends IndexServiceImpl implements VocabService {
 
     @Value("${elasticsearch.vocabs_index.name}")
     protected String vocabsIndexName;
@@ -50,14 +50,14 @@ public class VocabServiceImpl implements VocabService {
     protected static final String LABEL = "label";
     protected static final String ABOUT = "about";
 
-    // self-injection to avoid self-invocation problems when calling the cachable method within the same bean
+    // self-injection to avoid self-invocation problems when calling the cachable method within the same bean,
+    // and so BulkRequestProcessor can invoke @Retryable executeBulk through the Spring AOP proxy
     @Lazy
     @Autowired
-    VocabService self;
+    VocabServiceImpl self;
 
     protected ElasticsearchClient portalElasticsearchClient;
     protected ElasticSearchIndexService elasticSearchIndexService;
-    protected ObjectMapper indexerObjectMapper;
     protected ArdcVocabService ardcVocabService;
     protected String available = null;
     protected ExecutorService executorService = Executors.newFixedThreadPool(3);
@@ -90,10 +90,9 @@ public class VocabServiceImpl implements VocabService {
     public VocabServiceImpl(
             ArdcVocabService ardcVocabService,
             ObjectMapper indexerObjectMapper,
-            ElasticsearchClient portalElasticsearchClient,
+            @Qualifier("portalElasticsearchClient") ElasticsearchClient portalElasticsearchClient,
             ElasticSearchIndexService elasticSearchIndexService) {
-
-        this.indexerObjectMapper = indexerObjectMapper;
+        super(portalElasticsearchClient, indexerObjectMapper);
         this.ardcVocabService = ardcVocabService;
         this.portalElasticsearchClient = portalElasticsearchClient;
         this.elasticSearchIndexService = elasticSearchIndexService;
@@ -400,48 +399,70 @@ public class VocabServiceImpl implements VocabService {
         bulkIndexVocabs(vocabDtos);
     }
 
+    /**
+     * Index vocabs in size-limited bulk batches via {@link BulkRequestProcessor} / {@link #executeBulk},
+     * so large vocab trees do not hit Elasticsearch "entity too large" limits.
+     */
     protected void bulkIndexVocabs(List<VocabDto> vocabs) throws IOException {
-        if (!vocabs.isEmpty()) {
-            BulkRequest.Builder bulkRequest = new BulkRequest.Builder();
-
-            for (VocabDto vocab : vocabs) {
-                try {
-                    // convert vocab values to binary data
-                    log.debug("Ingested json is {}", indexerObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(vocab));
-                    // send bulk request to Elasticsearch
-                    bulkRequest.operations(op -> op
-                            .index(idx -> idx
-                                    .index(vocabsIndexName)
-                                    .document(vocab)
-                            )
-                    );
-                } catch (JsonProcessingException e) {
-                    log.error("Failed to ingest parameterVocabs to {}", vocabsIndexName);
-                    throw new RuntimeException(e);
-                }
-            }
-
-            BulkResponse result = portalElasticsearchClient.bulk(bulkRequest.build());
-
-            // Flush after insert, otherwise you need to wait for next auto-refresh. It is
-            // especially a problem with autotest, where assert happens very fast.
-            portalElasticsearchClient.indices().refresh();
-
-            // Log errors, if any
-            if (result.errors()) {
-                log.error("Bulk had errors");
-                for (BulkResponseItem item : result.items()) {
-                    if (item.error() != null) {
-                        log.error("{} {}", item.error().reason(), item.error().causedBy());
-                    }
-                }
-            } else {
-                log.info("Finished bulk indexing items to index: {}", vocabsIndexName);
-            }
-            log.info("Total documents in index: {} is {}", vocabsIndexName, elasticSearchIndexService.getDocumentsCount(vocabsIndexName));
-        } else {
+        if (vocabs.isEmpty()) {
             log.error("No vocabs to be indexed, nothing to index");
+            return;
         }
+
+        Map<String, VocabDto> byId = new HashMap<>();
+        for (VocabDto vocab : vocabs) {
+            byId.put(resolveVocabDocumentId(vocab), vocab);
+        }
+
+        Function<BulkResponseItem, Optional<VocabDto>> mapper = item ->
+                Optional.ofNullable(byId.get(item.id()));
+
+        BulkRequestProcessor<VocabDto> bulkRequestProcessor =
+                new BulkRequestProcessor<>(vocabsIndexName, mapper, self, null);
+
+        for (VocabDto vocab : vocabs) {
+            try {
+                log.debug("Ingested json is {}",
+                        indexerObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(vocab));
+            } catch (JsonProcessingException e) {
+                log.error("Failed to serialize vocab for indexing to {}", vocabsIndexName);
+                throw new RuntimeException(e);
+            }
+            // skipIndividualReport=true: vocab load is typically background and not streamed to a client
+            bulkRequestProcessor.processItem(resolveVocabDocumentId(vocab), vocab, true);
+        }
+
+        bulkRequestProcessor.flush();
+        log.info("Finished bulk indexing items to index: {}", vocabsIndexName);
+        log.info("Total documents in index: {} is {}",
+                vocabsIndexName, elasticSearchIndexService.getDocumentsCount(vocabsIndexName));
+    }
+
+    /**
+     * Stable document id so bulk retries overwrite rather than duplicate.
+     * Prefix by vocab type because about/label may not be unique across types.
+     */
+    protected String resolveVocabDocumentId(VocabDto vocab) {
+        if (vocab.getParameterVocabModel() != null) {
+            return "parameter:" + vocabIdPart(vocab.getParameterVocabModel());
+        }
+        if (vocab.getPlatformVocabModel() != null) {
+            return "platform:" + vocabIdPart(vocab.getPlatformVocabModel());
+        }
+        if (vocab.getOrganisationVocabModel() != null) {
+            return "organisation:" + vocabIdPart(vocab.getOrganisationVocabModel());
+        }
+        throw new IllegalArgumentException("VocabDto has no vocab model set");
+    }
+
+    protected String vocabIdPart(VocabModel model) {
+        if (model.getAbout() != null && !model.getAbout().isBlank()) {
+            return model.getAbout();
+        }
+        if (model.getLabel() != null && !model.getLabel().isBlank()) {
+            return model.getLabel();
+        }
+        throw new IllegalArgumentException("VocabModel has neither about nor label for document id");
     }
 
     /**


### PR DESCRIPTION
This case only happens if there is a need to refresh the vocab index

1. Use common function for bulk save, so that it is split into chunk, avoid too big doc update cause elastic reject
2. Make sure only one save happens across classes, again avoid too big doc although individual chunk may be fine but do it together may have problem